### PR TITLE
Add demo reload function

### DIFF
--- a/Block_Wrapper.spin
+++ b/Block_Wrapper.spin
@@ -40,9 +40,10 @@ VAR
 
 OBJ
 
-  Scribbler     : "scribbler"
-  Serial        : "FullDuplexSerial"
-  ServoDriver   : "Servo32v7"
+  Scribbler         : "scribbler"
+  Serial            : "FullDuplexSerial"
+  ServoDriver       : "Servo32v7"
+  Scribbler_Default : "scribbler_default"
 
 '---[Start of Program]---------------------------------------------------------
 
@@ -568,4 +569,11 @@ Pub Servo(Pin, Angle)
 Pub ServoStop(Pin)
 
   ServoDriver.Set(Pin, 0)
+
+
+' Load the default product demo into the S3
+Pub RestoreS3Demo()
+
+  Scribber_Default.Start
+
 


### PR DESCRIPTION
Adding Spin code within the block definitions is unworkable because something in the Blockly library is adding spaces to the beginning of the lines. Moving the new code into the Blockly_Wrapper.spin file since that is where everything else seems to live.
