### PR TITLE
Attempt to fix line sensing issue

### DIFF
--- a/Block_Wrapper.spin
+++ b/Block_Wrapper.spin
@@ -357,10 +357,7 @@ Pub SimpleLine(Condition, Location, Color) | Position
     result := TRUE
 
   if ||(WasLine[LEFT] - WasLine[RIGHT]) < 30          ' Low difference, not on an edge
-    if WasLine[LEFT] + WasLine[RIGHT] < 60            ' Average reading is dark
-      if Color == BLACK AND (Location == CENTER OR Location == DETECTED)
-        return
-    elseif Color == WHITE AND (Location == CENTER OR Location == DETECTED) ' Average reading is light
+    if WasLine[LEFT] + WasLine[RIGHT] => 60 AND Color == WHITE AND (Location == CENTER OR Location == DETECTED) ' Average reading is light
       return
   else                                                ' Over an edge
     if Location == DETECTED


### PR DESCRIPTION
There's a bug in the line sensing block wrapper that is preventing the S3 robot from differentiating the center of a line from the absence of a line.  This fix removes two lines that erroneously inverted the results when over the center of a dark line, while testing for the presence or absence of a line.  The preceding and following lines have also been merged into a single line, for readability.

I am attempting this fix from the Github web interface, because my test server is not currently running.  This fix will need to be tested in the Demo server.